### PR TITLE
Improve regex to check JWT Token format #5

### DIFF
--- a/kong/plugins/okta-auth/access.lua
+++ b/kong/plugins/okta-auth/access.lua
@@ -7,7 +7,9 @@ local function extract_token(request)
   local authorization = request.get_headers()["authorization"]
   if not authorization then return nil end
 
-  return string.match(authorization, '[Bb]earer ([^\n]+)')
+  return string.match(authorization,
+    '^[Bb]earer ([A-Za-z0-9-_]+%.[A-Za-z0-9-_]+%.[A-Za-z0-9-_]+)$'
+  )
 end
 
 local function is_token_valid(token_data)

--- a/spec/okta-auth/access_spec.lua
+++ b/spec/okta-auth/access_spec.lua
@@ -11,20 +11,42 @@ describe("Access", function()
       assert.is.not_true(valid)
     end)
 
-    it("return false if token in a wrong format", function()
+    it("return false if token type is not bearer or Bearer", function()
       request = {
-        get_headers = function(param) return { ["authorization"] = "token" } end
+        get_headers = function(param)
+          return { ["authorization"] = "token" }
+        end
+      }
+      valid, token_data = access.execute(request, {})
+      assert.is.not_true(valid)
+    end)
+
+    it("return false if token has not tree parts separated by period", function()
+      request = {
+        get_headers = function(param)
+          return { ["authorization"] = "Bearer part1.part2" }
+        end
+      }
+      valid, token_data = access.execute(request, {})
+      assert.is.not_true(valid)
+    end)
+
+    it("return false if token has invalid characters", function()
+      request = {
+        get_headers = function(param)
+          return { ["authorization"] = "Bearer pa*rt1.part2.part3" }
+        end
       }
       valid, token_data = access.execute(request, {})
       assert.is.not_true(valid)
     end)
   end)
 
-  describe("Token introspection", function()
+  describe("Introspection of a valid token", function()
     before_each(function()
       request = {
         get_headers = function(param)
-          return { ["authorization"] = "Bearer token" }
+          return { ["authorization"] = "Bearer header.body.signature" }
         end
       }
     end)

--- a/spec/okta-auth/access_spec.lua
+++ b/spec/okta-auth/access_spec.lua
@@ -21,7 +21,7 @@ describe("Access", function()
       assert.is.not_true(valid)
     end)
 
-    it("return false if token has not tree parts separated by period", function()
+    it("return false if token has not three parts separated by period", function()
       request = {
         get_headers = function(param)
           return { ["authorization"] = "Bearer part1.part2" }


### PR DESCRIPTION
This improves token regex validation. 

JSON Web Tokens consist of three parts separated by dots (.), which are: Header, Payload and Signature. Therefore, a JWT typically looks like: `xxxxx.yyyyy.zzzzz` (Reference: [JWT.io](https://jwt.io/introduction/))

JWTs are base64url encoded and they may contain the following characters ([RFC 7519](https://tools.ietf.org/html/rfc7519)):
- Letters (`A-Z ` `a-z`)
- Numbers (`0-9`)
- Hyphen (`-`) and Underscore (`_`) 

The regular expression that is being used covers both criteria (number of parts and allowed characters):

`^[Bb]earer ([A-Za-z0-9-_]+%.[A-Za-z0-9-_]+%.[A-Za-z0-9-_]+)$`

   